### PR TITLE
Update to 2.1.0-Preview1

### DIFF
--- a/Source/Examples/WPF/WpfExamples/Examples/CsvDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF/WpfExamples/Examples/CsvDemo/MainWindow.xaml.cs
@@ -143,7 +143,7 @@ namespace CsvDemo
 
         private void HelpWeb_Click(object sender, RoutedEventArgs e)
         {
-            Process.Start("http://oxyplot.org");
+            Process.Start("https://oxyplot.github.io/");
         }
     }
 }

--- a/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
+++ b/Source/Examples/WPF/WpfExamples/WpfExamples.csproj
@@ -6,7 +6,7 @@
       <OutputType>WinExe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Wpf" Version="2.1.0-unstable.1440" />
+    <PackageReference Include="OxyPlot.Wpf" Version="2.1.0-Preview1" />
     <ProjectReference Include="..\..\..\OxyPlot.Contrib.Wpf\OxyPlot.Contrib.Wpf.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/OxyPlot.Contrib.Wpf/OxyPlot.Contrib.Wpf.csproj
+++ b/Source/OxyPlot.Contrib.Wpf/OxyPlot.Contrib.Wpf.csproj
@@ -27,6 +27,6 @@
     <None Include="OxyPlot.Contrib.Wpf.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Wpf" Version="2.1.0-unstable.1440" />
+    <PackageReference Include="OxyPlot.Wpf" Version="2.1.0-Preview1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Change dependencies to OxyPlot 2.1-Preview1. Necessary before we release oxyplot-contrib as a preview.

Also fixes a references to the old website.

Once this is through, I'll push the packages to nuget and work on updating the WPF docs so that users are instructed to reference OxyPlot.Contrib.Wpf if they want to use the `Plot` (XAML) method. It probably makes the most sense to include that documentation in this repository as markdown, so that it can be updated independently of the main docs.