### PR TITLE
Fix callback for BarSeriesBase.ValueFieldProperty

### DIFF
--- a/Source/OxyPlot.Contrib.Wpf/Series/BarSeries/BarSeriesBase.cs
+++ b/Source/OxyPlot.Contrib.Wpf/Series/BarSeries/BarSeriesBase.cs
@@ -98,7 +98,7 @@ namespace OxyPlot.Wpf
         /// Identifies the <see cref="ValueField"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ValueFieldProperty = DependencyProperty.Register(
-            "ValueField", typeof(string), typeof(BarSeriesBase), new PropertyMetadata(null, AppearanceChanged));
+            "ValueField", typeof(string), typeof(BarSeriesBase), new PropertyMetadata(null, DataChanged));
 
         /// <summary>
         /// Initializes static members of the <see cref="BarSeriesBase" /> class.


### PR DESCRIPTION
Discovered in OxyPlot-Avalonia where it was causing issues (additional notes at https://github.com/oxyplot/oxyplot-avalonia/pull/38#issuecomment-997406491).

`ValueField` changes the data, so should call `DataChanged` when it's changed. For whatever reason this hasn't proved an issue, but perhaps could in the future.